### PR TITLE
Use standard sized types to address build issues

### DIFF
--- a/pyfastyaz0yay0.c
+++ b/pyfastyaz0yay0.c
@@ -1,10 +1,13 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include <stdint.h>
 
-typedef unsigned char bool;
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned long u32;
+typedef uint8_t bool;
+typedef uint8_t u8;
+
+typedef uint16_t u16;
+typedef uint32_t u32;
+
 #define true 1
 #define false 0
 


### PR DESCRIPTION
long is 8 bytes on linux, so this package doesn't build on linux because of pointers of different size between the declaration of get_match_length_and_distance and it's usage at line 336
This uses stdint to use sized standard types, so it should have no issues building on windows either.